### PR TITLE
fix: add a check for null pod metadata, which can occur even when the pod is metadata is non-null

### DIFF
--- a/extensions-core/kubernetes-extensions/pom.xml
+++ b/extensions-core/kubernetes-extensions/pom.xml
@@ -34,7 +34,7 @@
   </parent>
 
   <properties>
-    <kubernetes.client.version>16.0.0</kubernetes.client.version>
+    <kubernetes.client.version>11.0.3</kubernetes.client.version>
   </properties>
 
   <dependencies>

--- a/extensions-core/kubernetes-extensions/src/main/java/org/apache/druid/k8s/discovery/DefaultK8sApiClient.java
+++ b/extensions-core/kubernetes-extensions/src/main/java/org/apache/druid/k8s/discovery/DefaultK8sApiClient.java
@@ -65,7 +65,7 @@ public class DefaultK8sApiClient implements K8sApiClient
   public void patchPod(String podName, String podNamespace, String jsonPatchStr)
   {
     try {
-      coreV1Api.patchNamespacedPod(podName, podNamespace, new V1Patch(jsonPatchStr), "true", null, null, null, null);
+      coreV1Api.patchNamespacedPod(podName, podNamespace, new V1Patch(jsonPatchStr), "true", null, null, null);
     }
     catch (ApiException ex) {
       throw new RE(ex, "Failed to patch pod[%s/%s], code[%d], error[%s].", podNamespace, podName, ex.getCode(), ex.getResponseBody());

--- a/extensions-core/kubernetes-extensions/src/main/java/org/apache/druid/k8s/discovery/DefaultK8sApiClient.java
+++ b/extensions-core/kubernetes-extensions/src/main/java/org/apache/druid/k8s/discovery/DefaultK8sApiClient.java
@@ -134,16 +134,20 @@ public class DefaultK8sApiClient implements K8sApiClient
               if (item != null && item.type != null) {
                 DiscoveryDruidNodeAndResourceVersion result = null;
                 if (item.object != null && item.object.getMetadata() != null) {
-                  result = new DiscoveryDruidNodeAndResourceVersion(
-                    item.object.getMetadata().getResourceVersion(),
-                    getDiscoveryDruidNodeFromPodDef(nodeRole, item.object)
-                  );
+                  if (item.object.getMetadata().getAnnotations() != null) {
+                    result = new DiscoveryDruidNodeAndResourceVersion(
+                        item.object.getMetadata().getResourceVersion(),
+                        getDiscoveryDruidNodeFromPodDef(nodeRole, item.object)
+                    );
+                  } else {
+                    LOGGER.debug("item of type [%s] had NULL annotations when watching nodeRole [%s]", item.type, nodeRole);
+                  }
                 } else {
                   // The item's object, or the metadata it contains, can be null in some
                   // cases -- likely due to a blip in the k8s watch. Handle that by
                   // passing the null upwards. The caller needs to know that the object
                   // can be null.
-                  LOGGER.debug("item of type " + item.type + " was NULL or had NULL metadata when watching nodeRole [%s]", nodeRole);
+                  LOGGER.debug("item of type [%s] was NULL or had NULL metadata when watching nodeRole [%s]", item.type, nodeRole);
                 }
 
                 obj = new Watch.Response<DiscoveryDruidNodeAndResourceVersion>(

--- a/extensions-core/kubernetes-extensions/src/main/java/org/apache/druid/k8s/discovery/DefaultK8sApiClient.java
+++ b/extensions-core/kubernetes-extensions/src/main/java/org/apache/druid/k8s/discovery/DefaultK8sApiClient.java
@@ -139,9 +139,10 @@ public class DefaultK8sApiClient implements K8sApiClient
                     getDiscoveryDruidNodeFromPodDef(nodeRole, item.object)
                   );
                 } else {
-                  // The item's object can be null in some cases -- likely due to a blip
-                  // in the k8s watch. Handle that by passing the null upwards. The caller
-                  // needs to know that the object can be null.
+                  // The item's object, or the metadata it contains, can be null in some
+                  // cases -- likely due to a blip in the k8s watch. Handle that by
+                  // passing the null upwards. The caller needs to know that the object
+                  // can be null.
                   LOGGER.debug("item of type " + item.type + " was NULL or had NULL metadata when watching nodeRole [%s]", nodeRole);
                 }
 

--- a/extensions-core/kubernetes-extensions/src/main/java/org/apache/druid/k8s/discovery/DefaultK8sApiClient.java
+++ b/extensions-core/kubernetes-extensions/src/main/java/org/apache/druid/k8s/discovery/DefaultK8sApiClient.java
@@ -133,7 +133,7 @@ public class DefaultK8sApiClient implements K8sApiClient
               Watch.Response<V1Pod> item = watch.next();
               if (item != null && item.type != null) {
                 DiscoveryDruidNodeAndResourceVersion result = null;
-                if (item.object != null) {
+                if (item.object != null && item.object.getMetadata() != null) {
                   result = new DiscoveryDruidNodeAndResourceVersion(
                     item.object.getMetadata().getResourceVersion(),
                     getDiscoveryDruidNodeFromPodDef(nodeRole, item.object)
@@ -142,7 +142,7 @@ public class DefaultK8sApiClient implements K8sApiClient
                   // The item's object can be null in some cases -- likely due to a blip
                   // in the k8s watch. Handle that by passing the null upwards. The caller
                   // needs to know that the object can be null.
-                  LOGGER.debug("item of type " + item.type + " was NULL when watching nodeRole [%s]", nodeRole);
+                  LOGGER.debug("item of type " + item.type + " was NULL or had NULL metadata when watching nodeRole [%s]", nodeRole);
                 }
 
                 obj = new Watch.Response<DiscoveryDruidNodeAndResourceVersion>(


### PR DESCRIPTION
backported from https://github.com/apache/druid/pull/13175

- Revert to K8s API client jar 11.0.3 which contains the security fixes we need but no breaking changes