### PR TITLE
fix: The Kubernetes extension now supports modified pods by checking to see if a deletion timestamp has been set and cleans up the in-memory state if so

### DIFF
--- a/extensions-core/kubernetes-extensions/src/main/java/org/apache/druid/k8s/discovery/DefaultK8sApiClient.java
+++ b/extensions-core/kubernetes-extensions/src/main/java/org/apache/druid/k8s/discovery/DefaultK8sApiClient.java
@@ -125,7 +125,7 @@ public class DefaultK8sApiClient implements K8sApiClient
 
       return new WatchResult()
       {
-        private Watch.Response<DiscoveryDruidNodeAndResourceVersion> obj;
+        private Watch.Response<DiscoveryDruidNodeAndK8sMetadata> obj;
 
         @Override
         public boolean hasNext() throws SocketTimeoutException
@@ -134,10 +134,10 @@ public class DefaultK8sApiClient implements K8sApiClient
             while (watch.hasNext()) {
               Watch.Response<V1Pod> item = watch.next();
               if (item != null && item.type != null) {
-                DiscoveryDruidNodeAndResourceVersion result = null;
+                DiscoveryDruidNodeAndK8sMetadata result = null;
                 if (item.object != null && item.object.getMetadata() != null) {
                   if (item.object.getMetadata().getAnnotations() != null) {
-                    result = new DiscoveryDruidNodeAndResourceVersion(
+                    result = new DiscoveryDruidNodeAndK8sMetadata(
                         item.object.getMetadata().getResourceVersion(),
                         getDiscoveryDruidNodeFromPodDef(nodeRole, item.object),
                         creationTimestamp(item.object),
@@ -153,7 +153,7 @@ public class DefaultK8sApiClient implements K8sApiClient
                   LOGGER.debug("item of type [%s] was NULL or had NULL metadata when watching nodeRole [%s]", item.type, nodeRole);
                 }
 
-                obj = new Watch.Response<DiscoveryDruidNodeAndResourceVersion>(
+                obj = new Watch.Response<DiscoveryDruidNodeAndK8sMetadata>(
                     item.type,
                     result
                 );
@@ -175,7 +175,7 @@ public class DefaultK8sApiClient implements K8sApiClient
         }
 
         @Override
-        public Watch.Response<DiscoveryDruidNodeAndResourceVersion> next()
+        public Watch.Response<DiscoveryDruidNodeAndK8sMetadata> next()
         {
           return obj;
         }

--- a/extensions-core/kubernetes-extensions/src/main/java/org/apache/druid/k8s/discovery/DiscoveryDruidNodeAndK8sMetadata.java
+++ b/extensions-core/kubernetes-extensions/src/main/java/org/apache/druid/k8s/discovery/DiscoveryDruidNodeAndK8sMetadata.java
@@ -22,14 +22,14 @@ package org.apache.druid.k8s.discovery;
 import org.apache.druid.discovery.DiscoveryDruidNode;
 import org.joda.time.DateTime;
 
-public class DiscoveryDruidNodeAndResourceVersion
+public class DiscoveryDruidNodeAndK8sMetadata
 {
   private final String resourceVersion;
   private final DiscoveryDruidNode node;
   private final DateTime creationTimestamp;
   private final DateTime deletionTimestamp;
 
-  public DiscoveryDruidNodeAndResourceVersion(String resourceVersion, DiscoveryDruidNode node, DateTime creationTimestamp, DateTime deletionTimestamp)
+  public DiscoveryDruidNodeAndK8sMetadata(String resourceVersion, DiscoveryDruidNode node, DateTime creationTimestamp, DateTime deletionTimestamp)
   {
     this.resourceVersion = resourceVersion;
     this.node = node;

--- a/extensions-core/kubernetes-extensions/src/main/java/org/apache/druid/k8s/discovery/DiscoveryDruidNodeAndResourceVersion.java
+++ b/extensions-core/kubernetes-extensions/src/main/java/org/apache/druid/k8s/discovery/DiscoveryDruidNodeAndResourceVersion.java
@@ -20,21 +20,34 @@
 package org.apache.druid.k8s.discovery;
 
 import org.apache.druid.discovery.DiscoveryDruidNode;
+import org.joda.time.DateTime;
 
 public class DiscoveryDruidNodeAndResourceVersion
 {
   private final String resourceVersion;
   private final DiscoveryDruidNode node;
+  private final DateTime creationTimestamp;
+  private final DateTime deletionTimestamp;
 
-  public DiscoveryDruidNodeAndResourceVersion(String resourceVersion, DiscoveryDruidNode node)
+  public DiscoveryDruidNodeAndResourceVersion(String resourceVersion, DiscoveryDruidNode node, DateTime creationTimestamp, DateTime deletionTimestamp)
   {
     this.resourceVersion = resourceVersion;
     this.node = node;
+    this.creationTimestamp = creationTimestamp;
+    this.deletionTimestamp = deletionTimestamp;
   }
 
   public String getResourceVersion()
   {
     return resourceVersion;
+  }
+
+  public DateTime getCreationTimestamp() {
+    return creationTimestamp;
+  }
+
+  public DateTime getDeletionTimestamp() {
+    return deletionTimestamp;
   }
 
   public DiscoveryDruidNode getNode()

--- a/extensions-core/kubernetes-extensions/src/main/java/org/apache/druid/k8s/discovery/K8sDruidNodeDiscoveryProvider.java
+++ b/extensions-core/kubernetes-extensions/src/main/java/org/apache/druid/k8s/discovery/K8sDruidNodeDiscoveryProvider.java
@@ -275,6 +275,12 @@ public class K8sDruidNodeDiscoveryProvider extends DruidNodeDiscoveryProvider
                   case WatchResult.DELETED:
                     baseNodeRoleWatcher.childRemoved(item.object.getNode());
                     break;
+                  case WatchResult.MODIFIED:
+                    if (item.object.getCreationTimestamp() != null && item.object.getDeletionTimestamp() != null && item.object.getDeletionTimestamp().isAfter(item.object.getCreationTimestamp())) {
+                      LOGGER.info("Pod has been modified and has a deletion times " + item.object.getDeletionTimestamp() + " after the creation timestamp " + item.object.getCreationTimestamp() + ", treating the pod as deleted");
+                      baseNodeRoleWatcher.childRemoved(item.object.getNode());
+                    }
+                    break;
                   default:
                 }
 

--- a/extensions-core/kubernetes-extensions/src/main/java/org/apache/druid/k8s/discovery/K8sDruidNodeDiscoveryProvider.java
+++ b/extensions-core/kubernetes-extensions/src/main/java/org/apache/druid/k8s/discovery/K8sDruidNodeDiscoveryProvider.java
@@ -266,7 +266,7 @@ public class K8sDruidNodeDiscoveryProvider extends DruidNodeDiscoveryProvider
 
           try {
             while (iter.hasNext()) {
-              Watch.Response<DiscoveryDruidNodeAndResourceVersion> item = iter.next();
+              Watch.Response<DiscoveryDruidNodeAndK8sMetadata> item = iter.next();
               if (item != null && item.type != null && item.object != null) {
                 switch (item.type) {
                   case WatchResult.ADDED:
@@ -276,7 +276,7 @@ public class K8sDruidNodeDiscoveryProvider extends DruidNodeDiscoveryProvider
                     baseNodeRoleWatcher.childRemoved(item.object.getNode());
                     break;
                   case WatchResult.MODIFIED:
-                    if (item.object.getCreationTimestamp() != null && item.object.getDeletionTimestamp() != null && item.object.getDeletionTimestamp().isAfter(item.object.getCreationTimestamp())) {
+                    if (isPodDeleted(item)) {
                       LOGGER.info("Pod has been modified and has a deletion timestamp " + item.object.getDeletionTimestamp() + " after the creation timestamp " + item.object.getCreationTimestamp() + ", treating the pod as deleted");
                       baseNodeRoleWatcher.childRemoved(item.object.getNode());
                     }
@@ -374,5 +374,9 @@ public class K8sDruidNodeDiscoveryProvider extends DruidNodeDiscoveryProvider
     {
       baseNodeRoleWatcher.registerListener(listener);
     }
+  }
+
+  private static boolean isPodDeleted(Watch.Response<DiscoveryDruidNodeAndK8sMetadata> item) {
+    return item.object.getCreationTimestamp() != null && item.object.getDeletionTimestamp() != null && item.object.getDeletionTimestamp().isAfter(item.object.getCreationTimestamp());
   }
 }

--- a/extensions-core/kubernetes-extensions/src/main/java/org/apache/druid/k8s/discovery/K8sDruidNodeDiscoveryProvider.java
+++ b/extensions-core/kubernetes-extensions/src/main/java/org/apache/druid/k8s/discovery/K8sDruidNodeDiscoveryProvider.java
@@ -277,7 +277,7 @@ public class K8sDruidNodeDiscoveryProvider extends DruidNodeDiscoveryProvider
                     break;
                   case WatchResult.MODIFIED:
                     if (item.object.getCreationTimestamp() != null && item.object.getDeletionTimestamp() != null && item.object.getDeletionTimestamp().isAfter(item.object.getCreationTimestamp())) {
-                      LOGGER.info("Pod has been modified and has a deletion times " + item.object.getDeletionTimestamp() + " after the creation timestamp " + item.object.getCreationTimestamp() + ", treating the pod as deleted");
+                      LOGGER.info("Pod has been modified and has a deletion timestamp " + item.object.getDeletionTimestamp() + " after the creation timestamp " + item.object.getCreationTimestamp() + ", treating the pod as deleted");
                       baseNodeRoleWatcher.childRemoved(item.object.getNode());
                     }
                     break;

--- a/extensions-core/kubernetes-extensions/src/main/java/org/apache/druid/k8s/discovery/WatchResult.java
+++ b/extensions-core/kubernetes-extensions/src/main/java/org/apache/druid/k8s/discovery/WatchResult.java
@@ -31,7 +31,7 @@ public interface WatchResult
 
   boolean hasNext() throws SocketTimeoutException;
 
-  Watch.Response<DiscoveryDruidNodeAndResourceVersion> next();
+  Watch.Response<DiscoveryDruidNodeAndK8sMetadata> next();
 
   void close();
 }

--- a/extensions-core/kubernetes-extensions/src/main/java/org/apache/druid/k8s/discovery/WatchResult.java
+++ b/extensions-core/kubernetes-extensions/src/main/java/org/apache/druid/k8s/discovery/WatchResult.java
@@ -27,6 +27,7 @@ public interface WatchResult
 {
   String ADDED = "ADDED";
   String DELETED = "DELETED";
+  String MODIFIED = "MODIFIED";
 
   boolean hasNext() throws SocketTimeoutException;
 

--- a/extensions-core/kubernetes-extensions/src/test/java/org/apache/druid/k8s/discovery/K8sDruidNodeDiscoveryProviderTest.java
+++ b/extensions-core/kubernetes-extensions/src/test/java/org/apache/druid/k8s/discovery/K8sDruidNodeDiscoveryProviderTest.java
@@ -111,8 +111,8 @@ public class K8sDruidNodeDiscoveryProviderTest
         podInfo.getPodNamespace(), labelSelector, "v2", NodeRole.ROUTER)).andReturn(
         new MockWatchResult(
             ImmutableList.of(
-                  new Watch.Response<>(WatchResult.ADDED, new DiscoveryDruidNodeAndResourceVersion("v3", testNode4)),
-                  new Watch.Response<>(WatchResult.DELETED, new DiscoveryDruidNodeAndResourceVersion("v4", testNode2))
+                  new Watch.Response<>(WatchResult.ADDED, new DiscoveryDruidNodeAndResourceVersion("v3", testNode4, null, null)),
+                  new Watch.Response<>(WatchResult.DELETED, new DiscoveryDruidNodeAndResourceVersion("v4", testNode2, null, null))
               ),
             false,
             true
@@ -122,8 +122,8 @@ public class K8sDruidNodeDiscoveryProviderTest
         podInfo.getPodNamespace(), labelSelector, "v4", NodeRole.ROUTER)).andReturn(
         new MockWatchResult(
             ImmutableList.of(
-                new Watch.Response<>(WatchResult.ADDED, new DiscoveryDruidNodeAndResourceVersion("v5", testNode5)),
-                new Watch.Response<>(WatchResult.DELETED, new DiscoveryDruidNodeAndResourceVersion("v6", testNode3))
+                new Watch.Response<>(WatchResult.ADDED, new DiscoveryDruidNodeAndResourceVersion("v5", testNode5, null, null)),
+                new Watch.Response<>(WatchResult.DELETED, new DiscoveryDruidNodeAndResourceVersion("v6", testNode3, null, null))
             ),
             false,
             false
@@ -254,7 +254,7 @@ public class K8sDruidNodeDiscoveryProviderTest
         podInfo.getPodNamespace(), labelSelector, "v1", NodeRole.ROUTER)).andReturn(
         new MockWatchResult(
             ImmutableList.of(
-                  new Watch.Response<>(null, new DiscoveryDruidNodeAndResourceVersion("v2", testNode4))
+                  new Watch.Response<>(null, new DiscoveryDruidNodeAndResourceVersion("v2", testNode4, null, null))
               ),
             false,
             false
@@ -264,7 +264,7 @@ public class K8sDruidNodeDiscoveryProviderTest
         podInfo.getPodNamespace(), labelSelector, "v2", NodeRole.ROUTER)).andReturn(
         new MockWatchResult(
             ImmutableList.of(
-                  new Watch.Response<>(WatchResult.ADDED, new DiscoveryDruidNodeAndResourceVersion("v2", testNode4))
+                  new Watch.Response<>(WatchResult.ADDED, new DiscoveryDruidNodeAndResourceVersion("v2", testNode4, null, null))
               ),
             false,
             false

--- a/extensions-core/kubernetes-extensions/src/test/java/org/apache/druid/k8s/discovery/K8sDruidNodeDiscoveryProviderTest.java
+++ b/extensions-core/kubernetes-extensions/src/test/java/org/apache/druid/k8s/discovery/K8sDruidNodeDiscoveryProviderTest.java
@@ -163,7 +163,7 @@ public class K8sDruidNodeDiscoveryProviderTest
             MockListener.Event.added(testNode4),
             MockListener.Event.deleted(testNode2),
             MockListener.Event.added(testNode5),
-            MockListener.Event.deleted(testNode3)
+            MockListener.Event.deleted(testNode3),
             MockListener.Event.added(testNode5),
             MockListener.Event.deleted(testNode3)
         )

--- a/extensions-core/kubernetes-extensions/src/test/java/org/apache/druid/k8s/discovery/K8sDruidNodeDiscoveryProviderTest.java
+++ b/extensions-core/kubernetes-extensions/src/test/java/org/apache/druid/k8s/discovery/K8sDruidNodeDiscoveryProviderTest.java
@@ -30,6 +30,7 @@ import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.common.logger.Logger;
 import org.apache.druid.server.DruidNode;
 import org.easymock.EasyMock;
+import org.joda.time.DateTime;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -129,6 +130,17 @@ public class K8sDruidNodeDiscoveryProviderTest
             false
         )
     );
+    EasyMock.expect(mockK8sApiClient.watchPods(
+            podInfo.getPodNamespace(), labelSelector, "v6", NodeRole.ROUTER)).andReturn(
+            new MockWatchResult(
+                    ImmutableList.of(
+                            new Watch.Response<>(WatchResult.ADDED, new DiscoveryDruidNodeAndK8sMetadata("v7", testNode5, null, null)),
+                            new Watch.Response<>(WatchResult.MODIFIED, new DiscoveryDruidNodeAndK8sMetadata("v6", testNode3, DateTime.now().minusMinutes(1), DateTime.now()))
+                    ),
+                    false,
+                    false
+            )
+    );
     EasyMock.replay(mockK8sApiClient);
 
     K8sDruidNodeDiscoveryProvider discoveryProvider = new K8sDruidNodeDiscoveryProvider(
@@ -150,6 +162,8 @@ public class K8sDruidNodeDiscoveryProviderTest
             MockListener.Event.deleted(testNode1),
             MockListener.Event.added(testNode4),
             MockListener.Event.deleted(testNode2),
+            MockListener.Event.added(testNode5),
+            MockListener.Event.deleted(testNode3)
             MockListener.Event.added(testNode5),
             MockListener.Event.deleted(testNode3)
         )

--- a/extensions-core/kubernetes-extensions/src/test/java/org/apache/druid/k8s/discovery/K8sDruidNodeDiscoveryProviderTest.java
+++ b/extensions-core/kubernetes-extensions/src/test/java/org/apache/druid/k8s/discovery/K8sDruidNodeDiscoveryProviderTest.java
@@ -111,8 +111,8 @@ public class K8sDruidNodeDiscoveryProviderTest
         podInfo.getPodNamespace(), labelSelector, "v2", NodeRole.ROUTER)).andReturn(
         new MockWatchResult(
             ImmutableList.of(
-                  new Watch.Response<>(WatchResult.ADDED, new DiscoveryDruidNodeAndResourceVersion("v3", testNode4, null, null)),
-                  new Watch.Response<>(WatchResult.DELETED, new DiscoveryDruidNodeAndResourceVersion("v4", testNode2, null, null))
+                  new Watch.Response<>(WatchResult.ADDED, new DiscoveryDruidNodeAndK8sMetadata("v3", testNode4, null, null)),
+                  new Watch.Response<>(WatchResult.DELETED, new DiscoveryDruidNodeAndK8sMetadata("v4", testNode2, null, null))
               ),
             false,
             true
@@ -122,8 +122,8 @@ public class K8sDruidNodeDiscoveryProviderTest
         podInfo.getPodNamespace(), labelSelector, "v4", NodeRole.ROUTER)).andReturn(
         new MockWatchResult(
             ImmutableList.of(
-                new Watch.Response<>(WatchResult.ADDED, new DiscoveryDruidNodeAndResourceVersion("v5", testNode5, null, null)),
-                new Watch.Response<>(WatchResult.DELETED, new DiscoveryDruidNodeAndResourceVersion("v6", testNode3, null, null))
+                new Watch.Response<>(WatchResult.ADDED, new DiscoveryDruidNodeAndK8sMetadata("v5", testNode5, null, null)),
+                new Watch.Response<>(WatchResult.DELETED, new DiscoveryDruidNodeAndK8sMetadata("v6", testNode3, null, null))
             ),
             false,
             false
@@ -240,7 +240,7 @@ public class K8sDruidNodeDiscoveryProviderTest
             )
         )
     );
-    List<Watch.Response<DiscoveryDruidNodeAndResourceVersion>> nullList = new ArrayList<Watch.Response<DiscoveryDruidNodeAndResourceVersion>>();
+    List<Watch.Response<DiscoveryDruidNodeAndK8sMetadata>> nullList = new ArrayList<Watch.Response<DiscoveryDruidNodeAndK8sMetadata>>();
     nullList.add(null);
     EasyMock.expect(mockK8sApiClient.watchPods(
         podInfo.getPodNamespace(), labelSelector, "v1", NodeRole.ROUTER)).andReturn(
@@ -254,7 +254,7 @@ public class K8sDruidNodeDiscoveryProviderTest
         podInfo.getPodNamespace(), labelSelector, "v1", NodeRole.ROUTER)).andReturn(
         new MockWatchResult(
             ImmutableList.of(
-                  new Watch.Response<>(null, new DiscoveryDruidNodeAndResourceVersion("v2", testNode4, null, null))
+                  new Watch.Response<>(null, new DiscoveryDruidNodeAndK8sMetadata("v2", testNode4, null, null))
               ),
             false,
             false
@@ -264,7 +264,7 @@ public class K8sDruidNodeDiscoveryProviderTest
         podInfo.getPodNamespace(), labelSelector, "v2", NodeRole.ROUTER)).andReturn(
         new MockWatchResult(
             ImmutableList.of(
-                  new Watch.Response<>(WatchResult.ADDED, new DiscoveryDruidNodeAndResourceVersion("v2", testNode4, null, null))
+                  new Watch.Response<>(WatchResult.ADDED, new DiscoveryDruidNodeAndK8sMetadata("v2", testNode4, null, null))
               ),
             false,
             false
@@ -417,14 +417,14 @@ public class K8sDruidNodeDiscoveryProviderTest
 
   private static class MockWatchResult implements WatchResult
   {
-    private List<Watch.Response<DiscoveryDruidNodeAndResourceVersion>> results;
+    private List<Watch.Response<DiscoveryDruidNodeAndK8sMetadata>> results;
 
     private volatile boolean timeoutOnStart;
     private volatile boolean timeooutOnEmptyResults;
     private volatile boolean closeCalled = false;
 
     public MockWatchResult(
-        List<Watch.Response<DiscoveryDruidNodeAndResourceVersion>> results,
+        List<Watch.Response<DiscoveryDruidNodeAndK8sMetadata>> results,
         boolean timeoutOnStart,
         boolean timeooutOnEmptyResults
     )
@@ -459,7 +459,7 @@ public class K8sDruidNodeDiscoveryProviderTest
     }
 
     @Override
-    public Watch.Response<DiscoveryDruidNodeAndResourceVersion> next()
+    public Watch.Response<DiscoveryDruidNodeAndK8sMetadata> next()
     {
       return results.remove(0);
     }


### PR DESCRIPTION
<!-- Thanks for trying to help us make Apache Druid be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

<!-- Please read the doc for contribution (https://github.com/apache/druid/blob/master/CONTRIBUTING.md) before making this PR. Also, once you open a PR, please _avoid using force pushes and rebasing_ since these make it difficult for reviewers to see what you've changed in response to their reviews. See [the 'If your pull request shows conflicts with master' section](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#if-your-pull-request-shows-conflicts-with-master) for more details. -->

<!-- If you are a committer, follow the PR action item checklist for committers:
https://github.com/apache/druid/blob/master/dev/committer-instructions.md#pr-and-issue-action-item-checklist-for-committers. -->

### Description

The kubernetes extension only directly supports addition and deletion of pods.  The deletion for a pod does not arrive until the pod has been hard-deleted, creating a span of time during which the cluster can still think the pod is alive.  For instance, if an indexer pod is deleted, the process in the pod shuts down immediately, but the kubernetes deletion event doesn't occur until a later time.  During this time, the coordinator has a memory reference to the defunct pod and will continue attempting to communicate with it until the deletion officially occurs.  

<!-- Describe the goal of this PR, what problem are you fixing. If there is a corresponding issue (referenced above), it's not necessary to repeat the description here, however, you may choose to keep one summary sentence. -->

<!-- Describe your patch: what did you change in code? How did you fix the problem? -->

`K8sNodeDiscoveryProvider` now directly supports modified pods.  When a pod modification event is processed the pod metadata is checked to see if there is a creation timestamp and a deletion timestamp.  If both exist, and the deletion timestamp is after the creation timestamp, the pod can be considered immediately deleted.  In this situation the node information is removed from the coordinator memory and it stops attempting to communicate with the defunct pod.

This change entails added the two timestamps to `DruidDiscoveryNodeAndResourceVersion` which has been renamed too `DiscoveryDruidNodeAndK8sMetadata` as it now contains more information than just the pair indicated.

<!-- If there are several relatively logically separate changes in this PR, create a mini-section for each of them. For example: -->

#### Fixed the bug ...
#### Renamed the class ...
#### Added a forbidden-apis entry ...

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design (or naming) decision point and compare the alternatives with the designs that you've implemented (or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain what have changed in your final design compared to your original proposal or the consensus version in the end of the discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

<hr>

##### Key changed/added classes in this PR
 * `MyFoo`
 * `OurBar`
 * `TheirBaz`

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:
- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
