### PR TITLE
fix: [druid-kubernetes-extensions] Do not propagate k8s add/delete events for nodes with no services

### DIFF
--- a/extensions-core/kubernetes-extensions/src/main/java/org/apache/druid/k8s/discovery/K8sDiscoveryModule.java
+++ b/extensions-core/kubernetes-extensions/src/main/java/org/apache/druid/k8s/discovery/K8sDiscoveryModule.java
@@ -26,10 +26,6 @@ import com.google.inject.Key;
 import com.google.inject.Provider;
 import io.kubernetes.client.openapi.ApiClient;
 import io.kubernetes.client.util.Config;
-import java.text.DateFormat;
-import java.text.SimpleDateFormat;
-import java.util.Date;
-import java.util.TimeZone;
 import org.apache.druid.client.coordinator.Coordinator;
 import org.apache.druid.client.indexing.IndexingService;
 import org.apache.druid.discovery.DruidLeaderSelector;
@@ -43,8 +39,11 @@ import org.apache.druid.initialization.DruidModule;
 import org.apache.druid.server.DruidNode;
 
 import java.io.IOException;
+import java.text.SimpleDateFormat;
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
+import java.util.TimeZone;
 
 public class K8sDiscoveryModule implements DruidModule
 {
@@ -68,7 +67,7 @@ public class K8sDiscoveryModule implements DruidModule
                   // Note: we can probably improve things here about figuring out how to find the K8S API server,
                   // HTTP client timeouts etc.
                   final SimpleDateFormat dateFormat = new SimpleDateFormat(
-                      "yyyyMMdd'T'HHmmss.SSS'Z'");
+                      "yyyyMMdd'T'HHmmss.SSS'Z'", Locale.ENGLISH);
                   dateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
                   return Config.defaultClient().setDateFormat(dateFormat);
                 }

--- a/extensions-core/kubernetes-extensions/src/main/java/org/apache/druid/k8s/discovery/K8sDruidNodeDiscoveryProvider.java
+++ b/extensions-core/kubernetes-extensions/src/main/java/org/apache/druid/k8s/discovery/K8sDruidNodeDiscoveryProvider.java
@@ -278,9 +278,9 @@ public class K8sDruidNodeDiscoveryProvider extends DruidNodeDiscoveryProvider
                           item.object.getNode().getNodeRole(),
                           item.object.getNode().getDruidNode().getHostAndPort()
                       );
-                      break;
+                    } else {
+                      baseNodeRoleWatcher.childAdded(item.object.getNode());
                     }
-                    baseNodeRoleWatcher.childAdded(item.object.getNode());
                     break;
                   case WatchResult.DELETED:
                     if (item.object.getNode().getServices() == null || item.object.getNode().getServices().isEmpty()) {

--- a/extensions-core/kubernetes-extensions/src/main/java/org/apache/druid/k8s/discovery/K8sDruidNodeDiscoveryProvider.java
+++ b/extensions-core/kubernetes-extensions/src/main/java/org/apache/druid/k8s/discovery/K8sDruidNodeDiscoveryProvider.java
@@ -270,9 +270,17 @@ public class K8sDruidNodeDiscoveryProvider extends DruidNodeDiscoveryProvider
               if (item != null && item.type != null && item.object != null) {
                 switch (item.type) {
                   case WatchResult.ADDED:
+                    if (item.object.getNode().getServices() == null || item.object.getNode().getServices().isEmpty()) {
+                      LOGGER.warn("no services found on [%s] druid [%s] node [%s], skipping", item.type, item.object.getNode().getNodeRole(), item.object.getNode().getDruidNode().getHostAndPort());
+                      break;
+                    }
                     baseNodeRoleWatcher.childAdded(item.object.getNode());
                     break;
                   case WatchResult.DELETED:
+                    if (item.object.getNode().getServices() == null || item.object.getNode().getServices().isEmpty()) {
+                      LOGGER.warn("no services found on [%s] druid [%s] node [%s], skipping", item.type, item.object.getNode().getNodeRole(), item.object.getNode().getDruidNode().getHostAndPort());
+                      break;
+                    }
                     baseNodeRoleWatcher.childRemoved(item.object.getNode());
                     break;
                   default:

--- a/extensions-core/kubernetes-extensions/src/main/java/org/apache/druid/k8s/discovery/K8sDruidNodeDiscoveryProvider.java
+++ b/extensions-core/kubernetes-extensions/src/main/java/org/apache/druid/k8s/discovery/K8sDruidNodeDiscoveryProvider.java
@@ -188,7 +188,8 @@ public class K8sDruidNodeDiscoveryProvider extends DruidNodeDiscoveryProvider
     private final LifecycleLock lifecycleLock = new LifecycleLock();
 
     private final AtomicReference<Closeable> watchRef = new AtomicReference<>();
-    private static final Closeable STOP_MARKER = () -> {};
+    private static final Closeable STOP_MARKER = () -> {
+    };
 
     private final NodeRole nodeRole;
     private final BaseNodeRoleWatcher baseNodeRoleWatcher;
@@ -271,19 +272,30 @@ public class K8sDruidNodeDiscoveryProvider extends DruidNodeDiscoveryProvider
                 switch (item.type) {
                   case WatchResult.ADDED:
                     if (item.object.getNode().getServices() == null || item.object.getNode().getServices().isEmpty()) {
-                      LOGGER.warn("no services found on [%s] druid [%s] node [%s], skipping", item.type, item.object.getNode().getNodeRole(), item.object.getNode().getDruidNode().getHostAndPort());
+                      LOGGER.warn(
+                          "no services found on [%s] druid [%s] node [%s], skipping",
+                          item.type,
+                          item.object.getNode().getNodeRole(),
+                          item.object.getNode().getDruidNode().getHostAndPort()
+                      );
                       break;
                     }
                     baseNodeRoleWatcher.childAdded(item.object.getNode());
                     break;
                   case WatchResult.DELETED:
                     if (item.object.getNode().getServices() == null || item.object.getNode().getServices().isEmpty()) {
-                      LOGGER.warn("no services found on [%s] druid [%s] node [%s], skipping", item.type, item.object.getNode().getNodeRole(), item.object.getNode().getDruidNode().getHostAndPort());
+                      LOGGER.warn(
+                          "no services found on [%s] druid [%s] node [%s], skipping",
+                          item.type,
+                          item.object.getNode().getNodeRole(),
+                          item.object.getNode().getDruidNode().getHostAndPort()
+                      );
                       break;
                     }
                     baseNodeRoleWatcher.childRemoved(item.object.getNode());
                     break;
                   default:
+                    // Ignore all other types as only pod ADD and DELETE matter.
                 }
 
                 // This should be updated after the action has been dealt with successfully
@@ -352,7 +364,8 @@ public class K8sDruidNodeDiscoveryProvider extends DruidNodeDiscoveryProvider
       try {
         LOGGER.info("Stopping NodeRoleWatcher for [%s]...", nodeRole);
         // STOP_MARKER cannot throw exceptions on close(), so this is OK.
-        CloseableUtils.closeAndSuppressExceptions(STOP_MARKER, e -> {});
+        CloseableUtils.closeAndSuppressExceptions(STOP_MARKER, e -> {
+        });
         watchExecutor.shutdownNow();
 
         if (!watchExecutor.awaitTermination(15, TimeUnit.SECONDS)) {

--- a/extensions-core/kubernetes-extensions/src/main/java/org/apache/druid/k8s/discovery/K8sDruidNodeDiscoveryProvider.java
+++ b/extensions-core/kubernetes-extensions/src/main/java/org/apache/druid/k8s/discovery/K8sDruidNodeDiscoveryProvider.java
@@ -290,9 +290,9 @@ public class K8sDruidNodeDiscoveryProvider extends DruidNodeDiscoveryProvider
                           item.object.getNode().getNodeRole(),
                           item.object.getNode().getDruidNode().getHostAndPort()
                       );
-                      break;
+                    } else {
+                      baseNodeRoleWatcher.childRemoved(item.object.getNode());
                     }
-                    baseNodeRoleWatcher.childRemoved(item.object.getNode());
                     break;
                   default:
                     // Ignore all other types as only pod ADD and DELETE matter.

--- a/extensions-core/kubernetes-extensions/src/test/java/org/apache/druid/k8s/discovery/K8sDruidNodeDiscoveryProviderTest.java
+++ b/extensions-core/kubernetes-extensions/src/test/java/org/apache/druid/k8s/discovery/K8sDruidNodeDiscoveryProviderTest.java
@@ -25,6 +25,7 @@ import com.google.common.collect.Lists;
 import io.kubernetes.client.util.Watch;
 import org.apache.druid.discovery.DiscoveryDruidNode;
 import org.apache.druid.discovery.DruidNodeDiscovery;
+import org.apache.druid.discovery.LookupNodeService;
 import org.apache.druid.discovery.NodeRole;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.common.logger.Logger;
@@ -40,6 +41,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 
+import static org.easymock.EasyMock.mock;
+
 public class K8sDruidNodeDiscoveryProviderTest
 {
   private static final Logger LOGGER = new Logger(K8sDruidNodeDiscoveryProviderTest.class);
@@ -47,31 +50,31 @@ public class K8sDruidNodeDiscoveryProviderTest
   private final DiscoveryDruidNode testNode1 = new DiscoveryDruidNode(
       new DruidNode("druid/router", "test-host1", true, 80, null, true, false),
       NodeRole.ROUTER,
-      null
+      ImmutableMap.of("lookupNodeService", mock(LookupNodeService.class))
   );
 
   private final DiscoveryDruidNode testNode2 = new DiscoveryDruidNode(
       new DruidNode("druid/router", "test-host2", true, 80, null, true, false),
       NodeRole.ROUTER,
-      null
+      ImmutableMap.of("lookupNodeService", mock(LookupNodeService.class))
   );
 
   private final DiscoveryDruidNode testNode3 = new DiscoveryDruidNode(
       new DruidNode("druid/router", "test-host3", true, 80, null, true, false),
       NodeRole.ROUTER,
-      null
+      ImmutableMap.of("lookupNodeService", mock(LookupNodeService.class))
   );
 
   private final DiscoveryDruidNode testNode4 = new DiscoveryDruidNode(
       new DruidNode("druid/router", "test-host4", true, 80, null, true, false),
       NodeRole.ROUTER,
-      null
+      ImmutableMap.of("lookupNodeService", mock(LookupNodeService.class))
   );
 
   private final DiscoveryDruidNode testNode5 = new DiscoveryDruidNode(
       new DruidNode("druid/router", "test-host5", true, 80, null, true, false),
       NodeRole.ROUTER,
-      null
+      ImmutableMap.of("lookupNodeService", mock(LookupNodeService.class))
   );
 
   private final PodInfo podInfo = new PodInfo("testpod", "testns");


### PR DESCRIPTION
<!-- Thanks for trying to help us make Apache Druid be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

<!-- Please read the doc for contribution (https://github.com/apache/druid/blob/master/CONTRIBUTING.md) before making this PR. Also, once you open a PR, please _avoid using force pushes and rebasing_ since these make it difficult for reviewers to see what you've changed in response to their reviews. See [the 'If your pull request shows conflicts with master' section](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#if-your-pull-request-shows-conflicts-with-master) for more details. -->

Fixes #XXXX.

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

<!-- If you are a committer, follow the PR action item checklist for committers:
https://github.com/apache/druid/blob/master/dev/committer-instructions.md#pr-and-issue-action-item-checklist-for-committers. -->

### Description

<!-- Describe the goal of this PR, what problem are you fixing. If there is a corresponding issue (referenced above), it's not necessary to repeat the description here, however, you may choose to keep one summary sentence. -->

Prevent a NPE occurring in the coordinator when the indexer pod shuts down.  The exception results from a collision between the indexer and peon services that the indexer pod announces as they share the same host and port.  The announced peon publishes no services, causing the NPE at shutdown and triggering a leaked thread running a `ChangeRequestHttpSyncer` pointed at the no-longer-running indexer.

<!-- Describe your patch: what did you change in code? How did you fix the problem? -->

Filter out pod additions and deletions for nodes that do not publish services.

<!-- If there are several relatively logically separate changes in this PR, create a mini-section for each of them. For example: -->

#### Fixed the bug ...
#### Renamed the class ...
#### Added a forbidden-apis entry ...

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design (or naming) decision point and compare the alternatives with the designs that you've implemented (or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain what have changed in your final design compared to your original proposal or the consensus version in the end of the discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

<hr>

##### Key changed/added classes in this PR
 * `MyFoo`
 * `OurBar`
 * `TheirBaz`

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:
- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
